### PR TITLE
change vscode-shell from /bin/sh to /bin/bash

### DIFF
--- a/images/vscode/Dockerfile
+++ b/images/vscode/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/project
 ADD "https://github.com/codercom/code-server/releases/download/1.408-vsc1.32.0/code-server1.408-vsc1.32.0-linux-x64.tar.gz" ./archive.tar.gz
 RUN tar -xvzf archive.tar.gz --strip-components=1 --wildcards "*/code-server" && mv "code-server" /usr/local/bin && rm archive.tar.gz && apt-get update && apt-get install -y openssl net-tools
 
-RUN groupadd user && useradd -m -g user -s /bin/sh user;
+RUN groupadd user && useradd -m -g user -s /bin/bash user;
 EXPOSE 8443
 USER user
 ENTRYPOINT ["/usr/local/bin/code-server", "--no-auth", "--allow-http"]


### PR DESCRIPTION
Before this commit the arrow keys weren't working in the terminal:
![before](https://user-images.githubusercontent.com/4335621/58600720-52833780-824b-11e9-9137-a6e2546eaf4a.png)

After this commit they work:

![after](https://user-images.githubusercontent.com/4335621/58600731-5d3dcc80-824b-11e9-905a-83c4a27abd64.png)
